### PR TITLE
Changed URL from Makefile and added headers to staging_dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ You should see an OpenWrt welcome message.
 
 ##### Add ODTONE extensions
 
+Configure the PATH to use the toolchain gcc instead off the host gcc:
+
+      http://wiki.openwrt.org/doc/devel/crosscompile
+
 Go to your working directory and download the ODTONE extension.
 
     cd ~/odtonewrt/

--- a/odtone-0.6/Makefile
+++ b/odtone-0.6/Makefile
@@ -21,9 +21,9 @@ PKG_NAME_SHORT:=odtone
 PKG_NAME:=$(PKG_NAME_SHORT)
 PKG_VERSION:=0.6
 
-PKG_SOURCE:=$(PKG_NAME_SHORT)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:= http://atnog.av.it.pt/odtone/files/releases
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME_SHORT)-$(PKG_VERSION)
+PKG_SOURCE:=v$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:= https://github.com/ATNoG/ODTONE/archive
+PKG_BUILD_DIR:=$(BUILD_DIR)/ODTONE-$(PKG_VERSION)
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -59,7 +59,7 @@ define Build/Compile
 		STRIP=$(GNU_TARGET_NAME)-strip \
 		OBJCOPY=$(GNU_TARGET_NAME)-objcopy \
 		OBJDUMP=$(GNU_TARGET_NAME)-objdump \
-		b2 src/mihf app/sap_80211_linux \
+		b2  src/mihf  app/sap_80211_linux  \
 			$(filter -j%,$(PKG_JOBS)) \
 			toolset=gcc-$(ARCH) --build-type=minimal --layout=system optimization=space \
 			--disable-long-double link=shared runtime-link=shared inlining=on debug-symbols=off \
@@ -73,8 +73,8 @@ define Package/odtone/install
 	$(INSTALL_BIN) ./files/etc/init.d/odtone $(1)/etc/init.d
 
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_BUILD_DIR)/bin.v2/lib/external/libnl/gcc-mipsel/release/inlining-on/optimization-space/libnlwrap.so $(1)/usr/lib/
-	$(CP) $(PKG_BUILD_DIR)/bin.v2/lib/odtone/gcc-mipsel/release/inlining-on/optimization-space/libodtone.so $(1)/usr/lib/
+	$(CP) $(PKG_BUILD_DIR)/bin.v2/lib/external/libnl/gcc-$(ARCH)/release/inlining-on/optimization-space/libnlwrap.so $(1)/usr/lib/
+	$(CP) $(PKG_BUILD_DIR)/bin.v2/lib/odtone/gcc-$(ARCH)/release/inlining-on/optimization-space/libodtone.so $(1)/usr/lib/
 
 	$(INSTALL_DIR) $(1)/sbin/
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/dist/sap_80211 $(1)/sbin/

--- a/odtone-0.6/Makefile
+++ b/odtone-0.6/Makefile
@@ -59,7 +59,7 @@ define Build/Compile
 		STRIP=$(GNU_TARGET_NAME)-strip \
 		OBJCOPY=$(GNU_TARGET_NAME)-objcopy \
 		OBJDUMP=$(GNU_TARGET_NAME)-objdump \
-		b2  src/mihf  app/sap_80211_linux  \
+		b2  src/mihf  app/sap_80211_linux app/sap_8023 \
 			$(filter -j%,$(PKG_JOBS)) \
 			toolset=gcc-$(ARCH) --build-type=minimal --layout=system optimization=space \
 			--disable-long-double link=shared runtime-link=shared inlining=on debug-symbols=off \
@@ -76,15 +76,16 @@ define Package/odtone/install
 	$(CP) $(PKG_BUILD_DIR)/bin.v2/lib/external/libnl/gcc-$(ARCH)/release/inlining-on/optimization-space/libnlwrap.so $(1)/usr/lib/
 	$(CP) $(PKG_BUILD_DIR)/bin.v2/lib/odtone/gcc-$(ARCH)/release/inlining-on/optimization-space/libodtone.so $(1)/usr/lib/
 
-	$(INSTALL_DIR) $(1)/sbin/
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/dist/sap_80211 $(1)/sbin/
-
 	$(INSTALL_DIR) $(1)/usr/bin/
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/dist/odtone-mihf $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/dist/sap_80211 $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/dist/sap_8023 $(1)/usr/bin/
 
 	$(INSTALL_DIR) $(1)/etc/odtone
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/dist/odtone.conf $(1)/etc/odtone/
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/dist/sap_80211.conf $(1)/etc/odtone/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/dist/sap_8023.conf $(1)/etc/odtone/
+
 endef
 
 $(eval $(call BuildPackage,odtone))

--- a/odtone-0.6/Makefile
+++ b/odtone-0.6/Makefile
@@ -59,7 +59,7 @@ define Build/Compile
 		STRIP=$(GNU_TARGET_NAME)-strip \
 		OBJCOPY=$(GNU_TARGET_NAME)-objcopy \
 		OBJDUMP=$(GNU_TARGET_NAME)-objdump \
-		b2  src/mihf  app/sap_80211_linux app/sap_8023 \
+		b2  src/mihf  app/sap_80211_linux app/sap_8023 app/link_sap_icmp app/link_sap \
 			$(filter -j%,$(PKG_JOBS)) \
 			toolset=gcc-$(ARCH) --build-type=minimal --layout=system optimization=space \
 			--disable-long-double link=shared runtime-link=shared inlining=on debug-symbols=off \
@@ -80,11 +80,14 @@ define Package/odtone/install
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/dist/odtone-mihf $(1)/usr/bin/
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/dist/sap_80211 $(1)/usr/bin/
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/dist/sap_8023 $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/dist/link_sap_icmp $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/dist/link_sap $(1)/usr/bin/
 
 	$(INSTALL_DIR) $(1)/etc/odtone
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/dist/odtone.conf $(1)/etc/odtone/
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/dist/sap_80211.conf $(1)/etc/odtone/
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/dist/sap_8023.conf $(1)/etc/odtone/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/dist/link_sap.conf $(1)/etc/odtone/
 
 endef
 

--- a/odtone-0.6/Makefile
+++ b/odtone-0.6/Makefile
@@ -91,4 +91,18 @@ define Package/odtone/install
 
 endef
 
+
+define Build/InstallDev
+
+	$(INSTALL_DIR) $(1)/usr/lib
+
+	$(CP) $(PKG_BUILD_DIR)/bin.v2/lib/odtone/gcc-$(ARCH)/release/inlining-on/optimization-space/libodtone.so $(1)/usr/lib/
+
+	$(INSTALL_DIR) $(1)/usr/include/odtone
+	$(CP) $(PKG_BUILD_DIR)/inc/odtone/* $(1)/usr/include/odtone/
+
+
+endef
+
+
 $(eval $(call BuildPackage,odtone))

--- a/odtone-0.6/patches/004-Dynamic-linkage-with-boost-libraries.patch
+++ b/odtone-0.6/patches/004-Dynamic-linkage-with-boost-libraries.patch
@@ -1,11 +1,23 @@
 diff --git a/Jamroot b/Jamroot
-index 801c312..596a410 100644
+index debc5b2..71a8821 100644
 --- a/Jamroot
 +++ b/Jamroot
-@@ -40,28 +40,6 @@ project odtone
+@@ -25,8 +25,8 @@ import path ;
+ project odtone
+ 	: requirements
+ 		<include>inc
+-		<link>static
+-		<runtime-link>static
++		<link>shared
++		<runtime-link>shared
+ 		<toolset>gcc:<cxxflags>-std=c++0x
+ 		<toolset>gcc-android:<runtime-link>static
+ 		<toolset>msvc:<define>BOOST_ALL_NO_LIB
+@@ -41,27 +41,6 @@ project odtone
+ 
  path-constant odtone-root : . ;
  
- #
+-#
 -# Import the boost project
 -#
 -local boost-major = 1 ;
@@ -26,11 +38,9 @@ index 801c312..596a410 100644
 -	     "(--boost-root=/path/to/boost) or in the environment variable BOOST_ROOT" ;
 -}
 -use-project boost : $(boost-root) ;
--
--#
- # General utilities
+ 
  #
- rule explicit-alias ( main-target-name :
+ # General utilities
 diff --git a/app/sap_80211_linux/Jamfile b/app/sap_80211_linux/Jamfile
 index 0966abc..926df44 100644
 --- a/app/sap_80211_linux/Jamfile
@@ -41,12 +51,12 @@ index 0966abc..926df44 100644
  	  ../../lib/odtone//odtone
 -	  /boost//program_options
 -	: <link>static
-+	: <link>shared
++	: <link>shared <runtime-link>shared
  	;
  
  install install
 diff --git a/lib/external/libnl/Jamfile b/lib/external/libnl/Jamfile
-index 39d78b5..419b9ee 100644
+index 39d78b5..fd8d10e 100644
 --- a/lib/external/libnl/Jamfile
 +++ b/lib/external/libnl/Jamfile
 @@ -53,5 +53,5 @@ lib nlwrap
@@ -54,10 +64,10 @@ index 39d78b5..419b9ee 100644
  	:
  	:
 -	: <include>nlwrap
-+	: <include>nlwrap <link>static
++        : <include>nlwrap <link>static
  	;
 diff --git a/lib/odtone/Jamfile b/lib/odtone/Jamfile
-index e660037..880068a 100644
+index 3f37d29..55545e3 100644
 --- a/lib/odtone/Jamfile
 +++ b/lib/odtone/Jamfile
 @@ -51,9 +51,6 @@ lib odtone
@@ -67,9 +77,9 @@ index e660037..880068a 100644
 -	  /boost//system
 -	  /boost//thread
 -	  /boost//program_options
- 	  pthread
  	: <c++-template-depth>1024
  	  <define>BOOST_ENABLE_ASSERT_HANDLER
+ 	;
 diff --git a/src/mihf/Jamfile b/src/mihf/Jamfile
 index 71a2a77..38cca98 100644
 --- a/src/mihf/Jamfile


### PR DESCRIPTION
I've changed the PKG_SOURCE_URL in Makefile because the old one was giving a error 404.

In install process i copied the odtone headers to staging_dir, this is necessary to compile the ieee802.21 driver for OPMIP.
I have a fork of opmip for openwrt (https://github.com/hugo-ma-alves/opmip-openwrt). I'm still testing, but i already have a image compiled for mips and x86.

Because i am testing odtone in vmware it was useful to me to add the other link_saps to compilation, i understand that this is not important in a router.
